### PR TITLE
ALR-93 [OmbuLabs] Fix cache cloned deprecation warning

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -4,7 +4,7 @@ module Globalize
 
       class WhereChain < ::ActiveRecord::QueryMethods::WhereChain
         def not(opts, *rest)
-          if parsed = @scope.parse_translated_conditions(opts)
+          if parsed = @scope.clone.parse_translated_conditions(opts)
             @scope.join_translations.where.not(parsed, *rest)
           else
             super


### PR DESCRIPTION
Hello! This pull request fixes the following deprecation warning:
  
DEPRECATION WARNING: Modifying already cached Relation. The cache will be reset. Use a cloned Relation to prevent this warning.

You can read more about the deprecation here:
https://github.com/rails/rails/commit/1b7aa62b184c4410c99208f71b59bbac5c5f03be

We are following the fix that they used in the main version of the globalize gem to solve this issue. You can see the discussion and the commit that they used here:

https://github.com/globalize/globalize/issues/531

We ran a set of tests in cbx4 pointing to a local version of the this gem with the fix and it fixed the deprecation warnings. Let us know if you have any questions.