### PR TITLE
PLAT-1393 - upgrade Ruby 3.1

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -20,6 +20,7 @@ module Globalize
 
   CURRENT_RUBY     = Gem::Version.new(RUBY_VERSION)
   RUBY_VERSION_27  = Gem::Version.new('2.7.0')
+  RUBY_VERSION_31  = Gem::Version.new('3.1.6')
 
   class << self
     def locale
@@ -70,6 +71,10 @@ module Globalize
 
     def ruby_27?
       CURRENT_RUBY >= RUBY_VERSION_27
+    end
+
+    def ruby_31?
+      CURRENT_RUBY >= RUBY_VERSION_31
     end
 
     def rails_42?

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -147,7 +147,22 @@ module Globalize
         Globalize.fallbacks(locale)
       end
 
-      if Globalize.ruby_27?
+      if Globalize.ruby_31?
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def save(*args, **kwargs)
+            result = Globalize.with_locale(translation.locale || I18n.default_locale) do
+              without_fallbacks do
+                super(*args, **kwargs)
+              end
+            end
+            if result
+              globalize.clear_dirty
+            end
+
+            result
+          end
+        RUBY
+      elsif Globalize.ruby_27?
         class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def save(...)
             result = Globalize.with_locale(translation.locale || I18n.default_locale) do


### PR DESCRIPTION
PLAT-1393 - upgrade Ruby 3.1 no longer expands option hashes to keyword arguments so where Rails has an explicit `**options` it now fails with an `ArgumentError`